### PR TITLE
fixed pennylane warning that measurements in qasm circuits are being ignored

### DIFF
--- a/src/quafel/pipelines/data_science/frameworks.py
+++ b/src/quafel/pipelines/data_science/frameworks.py
@@ -77,7 +77,9 @@ class pennylane_fw:
                 "lightning.qubit", wires=range(self.n_qubits), shots=self.n_shots
             )
 
-        self.qml_qasm = qml.from_qasm(qasm_circuit)
+        # Pennylane does not support measurements at the moment
+        qasm_circuit_wo_measurement = re.sub(r"measure.*;\n", "", qasm_circuit)
+        self.qml_qasm = qml.from_qasm(qasm_circuit_wo_measurement)
 
         @qml.qnode(self.backend)
         def circuit():


### PR DESCRIPTION
Added regex based replacement of the measurement operator to resolve #57 
According to the [Pennylane Documentation](https://docs.pennylane.ai/en/stable/code/api/pennylane.counts.html), .counts() still uses the the provided shots to calculate the counts, thus no change in functionality with this PR.