### PR TITLE
Pipeline resuming

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,6 +76,19 @@
             "justMyCode": true
         },
         {
+            "name": "Ct. Measure - SP",
+            "type": "python",
+            "request": "launch",
+            "module": "kedro",
+            "args": [
+                "run",
+                "--pipeline",
+                "ctmeasure",
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": true
+        },
+        {
             "name": "Ct. Measure - MP",
             "type": "python",
             "request": "launch",

--- a/src/quafel/pipeline_registry.py
+++ b/src/quafel/pipeline_registry.py
@@ -29,21 +29,21 @@ def register_pipelines() -> Dict[str, Pipeline]:
     existing_results = [
         Path(f).stem for f in glob.glob("data/04_execution_results/*.csv")
     ]
-    existing_circuits = [
-        Path(f).stem for f in glob.glob("data/04_execution_results/*.csv")
-    ]
+    # existing_circuits = [
+    #     Path(f).stem for f in glob.glob("data/03_qasm_circuits/*.txt")
+    # ]
 
     # get the intersection of the durations and results
     existing_evals = [m for m in existing_durations if m in existing_results]
     # .. and the intersection of all partitions
     eval_partitions = [p for p in all_partitions if p not in existing_evals]
-    circuit_partitions = [p for p in all_partitions if p not in existing_circuits]
+    # circuit_partitions = [p for p in all_partitions if p not in existing_circuits]
 
     # gather all the .tmp files to create figures output
     tmp_files = [Path(f).stem for f in glob.glob("data/07_reporting/*.tmp")]
 
     # pass only the number of partitions we want to generate circuits for
-    dg_pipelines = dg.create_pipeline(partitions=circuit_partitions)
+    dg_pipelines = dg.create_pipeline(partitions=eval_partitions)
     # pass only the number of partitions we want to evaluate (this would be equal to all partitions in an initial run or in case we don't want to restore existing results)
     ds_pipelines = ds.create_pipeline(partitions=eval_partitions)
     viz_pipelines = viz.create_pipeline(figures=tmp_files)

--- a/src/quafel/pipeline_registry.py
+++ b/src/quafel/pipeline_registry.py
@@ -29,20 +29,24 @@ def register_pipelines() -> Dict[str, Pipeline]:
     existing_results = [
         Path(f).stem for f in glob.glob("data/04_execution_results/*.csv")
     ]
+    existing_circuits = [
+        Path(f).stem for f in glob.glob("data/04_execution_results/*.csv")
+    ]
 
     # get the intersection of the durations and results
-    existing_measurements = [m for m in existing_durations if m in existing_results]
+    existing_evals = [m for m in existing_durations if m in existing_results]
     # .. and the intersection of all partitions
-    partitions = [p for p in all_partitions if p not in existing_measurements]
+    eval_partitions = [p for p in all_partitions if p not in existing_evals]
+    circuit_partitions = [p for p in all_partitions if p not in existing_circuits]
 
     # gather all the .tmp files to create figures output
-    figures = [Path(f).stem for f in glob.glob("data/07_reporting/*.tmp")]
+    tmp_files = [Path(f).stem for f in glob.glob("data/07_reporting/*.tmp")]
 
-    # pass all partitions to data generation, since we need to recreate intermediate data
-    dg_pipelines = dg.create_pipeline(partitions=all_partitions)
+    # pass only the number of partitions we want to generate circuits for
+    dg_pipelines = dg.create_pipeline(partitions=circuit_partitions)
     # pass only the number of partitions we want to evaluate (this would be equal to all partitions in an initial run or in case we don't want to restore existing results)
-    ds_pipelines = ds.create_pipeline(partitions=partitions)
-    viz_pipelines = viz.create_pipeline(figures=figures)
+    ds_pipelines = ds.create_pipeline(partitions=eval_partitions)
+    viz_pipelines = viz.create_pipeline(figures=tmp_files)
 
     return {
         "__default__": dg_pipelines["pl_generate_evaluation_partitions"]
@@ -58,8 +62,8 @@ def register_pipelines() -> Dict[str, Pipeline]:
         # ct measure is the same as the measure pipeline, but we need to tell the hooks that we don't want to delete the existing results
         "combine": ds_pipelines["pl_combine_evaluations"],
         "ctmeasure": dg_pipelines[
-            "pl_generate_qasm_circuits"
-            # "pl_generate_qasm_circuits_splitted"
+            # "pl_generate_qasm_circuits"
+            "pl_generate_qasm_circuits_splitted"
         ]
         + ds_pipelines["pl_parallel_measure_execution_durations"],
         "visualize": viz_pipelines["pl_visualize_evaluations"],


### PR DESCRIPTION
This PR improves the ability to resume a pipeline by skipping the circuit generation for already existing results.
This was enabled by actually writing the circuits to disk compared to the previous approach before #53  where the circuits were stored in-memory.
Note that this can further be improved if the other configuration parameters e.g. `n_shots`, `n_qubits`.. could be retrieved separately from the partitions.